### PR TITLE
Patch 1

### DIFF
--- a/bin/download.js
+++ b/bin/download.js
@@ -12,7 +12,7 @@ const { homedir } = require('os')
 const { join, dirname } = require('path')
 const { get } = require('axios')
 const ProgressBar = require('progress')
-const unzip = require('unzip').Parse
+const unzip = require('unzipper').Parse
 const mkdirp = require('mkdirp').sync
 
 let versionPath = join(__dirname, 'version')

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "natives": "^1.1.6",
     "progress": "^2.0.0",
     "tendermint": "^4.0.7",
-    "unzip": "^0.1.11"
+    "unzipper": "^0.10.5"
   },
   "devDependencies": {
     "ava": "^0.25.0",


### PR DESCRIPTION
Fix for https://github.com/nomic-io/tendermint-node/issues/7

The unzip package is causing trouble with node.js latest versions.